### PR TITLE
Add setDomStorageEnabled(true) for popup WebView, some OAuth pages rely on it

### DIFF
--- a/connect-sdk/src/main/java/com/finicity/connect/sdk/ConnectWebChromeClient.java
+++ b/connect-sdk/src/main/java/com/finicity/connect/sdk/ConnectWebChromeClient.java
@@ -88,6 +88,11 @@ class ConnectWebChromeClient extends WebChromeClient {
         final WebView popupView = new WebView(mConnect);
 
         popupView.getSettings().setJavaScriptEnabled(true);
+
+        // DOM storage API is required for some OAuth pages,
+        // for instance Citibank relies on it.
+        popupView.getSettings().setDomStorageEnabled(true);
+
         popupView.setWebChromeClient(new WebChromeClient() {
             @Override
             public void onCloseWindow(WebView window) {


### PR DESCRIPTION
Hello. 
We use connect-android-sdk v1.0.4, which is latest officially published version.

We have an issue with Citibank OAuth page, it doesn't rendered correctly.  Users see empty screen instead of login page.

It's possible to replicate issue using demo-app from this repository, if you'll generate link to Citibank OAuth (institutionId = 170881). 
**NOTE**: because master branch contains some commits after v.1.0.4, I've had to checkout to tag of latest release, because this corresponds to SDK version we use.  Videos below are recorded using demo-app with connect-sdk 1.0.4.
`git checkout v1.0.4`

Here's video of what happening when you try to open Citibank OAuth page : https://drive.google.com/file/d/1tmcg2gweyzc6QFxfCEbq0QGgdVJTi_N7/view?usp=sharing

We assume that Citibank OAuth page is relying on Web Storage API (see extra info about API [here](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API)).

Support of this API is disabled by default in WebView.

And here's what happening when you add `getSettings().setDomStorageEnabled(true)` for popup WebView (which is responsible for rendering of OAuth pages):
https://drive.google.com/file/d/1j8VWMcSbChTn9lJNVBwB15PZqOmE9hYM/view?usp=sharing
Citibank OAuth login page is displayed successfully. 

This pull request adds call of setDomStorageEnabled(true) in order to fix issue with rendering of Citibank page.
As far as we can see, no issues is introduced by this change, OAuth pages of other banks are displayed correctly.

**NOTE**:  do not try to reproduce this issue using latest code from master branch, because latest code is using Chrome CustomTabs to render OAuth pages.  And this issue is not reproduced on Chrome, probably its supports WebStorage API by default.  
Using Custom Tabs is great idea, but I believe such migration would require some extra testing of new implementation (and that's probably why it is still not released). 

So it would be perfect, if you publish new version of connect-android-sdk with just this particular fix. 
For instance v1.0.5, which adds on top of v.1.0.4 just this commit. 

Thanks.
